### PR TITLE
Remove paragraph that is part of the next section

### DIFF
--- a/forallx-yyc-what.tex
+++ b/forallx-yyc-what.tex
@@ -57,8 +57,6 @@ name=conclusion indicator,
 description={a word or phrase such as ``therefore'' used to indicate that what follows is the conclusion of an argument.}
 }
 
-To be perfectly general, we can define an \define{argument} as a series of sentences. The sentences at the beginning of the series are premises. The final sentence in the series is the conclusion. If the premises are true and the argument is a good one, then you have a reason to accept the conclusion.
-
 \newglossaryentry{argument}
 {
 name=argument,


### PR DESCRIPTION
The paragraph already appears in the beginning of the next section (1.1 Sentences.) So, its presence in the introduction seems unnecessary. 