### PR TITLE
Update a few exercises that used \tnd

### DIFF
--- a/solutions/forallx-sol-prooftfl.tex
+++ b/solutions/forallx-sol-prooftfl.tex
@@ -430,14 +430,17 @@ Show that each of the following sentences is a theorem:
 \item $N \eor \enot N$
 \myanswer{\begin{proof}
 \open
-	\hypo{n}{N}
-	\have{nnn}{N \eor \enot N}\oi{n}
+        \hypo{ncon}{\enot (N \eor \enot N)}
+        \open
+                \hypo{n}{N}
+                \have{nnn1}{N \eor \enot N}\oi{n}
+                \have{bot1}{\ered}\ri{ncon, nnn1}
+        \close
+        \have{nn}{\enot N}\ni{n-bot1}
+        \have{nnn2}{N \eor \enot N}\oi{nn}
+        \have{bot2}{\ered}\ri{ncon, nnn2}
 \close
-\open
-	\hypo{nn}{\enot N}
-	\have{nnn1}{N \eor \enot N}\oi{nn}
-\close
-\have{con}{N \eor \enot N}\tnd{n-nnn, nn-nnn1}
+\have{con}{N \eor \enot N}\ip{ncon-bot2}
 \end{proof}}
 
 \newpage

--- a/solutions/forallx-sol-prooftfl.tex
+++ b/solutions/forallx-sol-prooftfl.tex
@@ -496,17 +496,20 @@ Provide proofs to show each of the following:
 \item $C\eif(E\eand G), \enot C \eif G \proves G$
 \myanswer{\begin{proof}
 \hypo{ceg}{C \eif (E \eand G)}
-\hypo{ncG}{\enot C \eif G}
+\hypo{ncg}{\enot C \eif G}
 \open
-	\hypo{c}{C}
-	\have{eg}{E \eand G}\ce{ceg, c}
-	\have{g}{G}\ae{eg}
+        \hypo{ng}{\enot G}
+        \open
+                \hypo{c}{C}
+                \have{eg}{E \eand G}\ce{ceg, c}
+                \have{g1}{G}\ae{eg}
+                \have{bot1}{\ered}\ri{ng, g1}
+        \close
+        \have{nc}{\enot C}\ni{c-bot1}
+        \have{g2}{G}\ce{ncg, nc}
+        \have{bot2}{\ered}\ri{ng, g2}
 \close
-\open
-	\hypo{nc}{\enot C}
-	\have{g1}{G}\ce{ncG, nc}
-\close
-\have{g2}{G}\tnd{c-g, nc-g1}
+\have{con}{G}\ip{ng-bot2}
 \end{proof}}
 
 \item $M \eand (\enot N \eif \enot M) \proves (N \eand M) \eor \enot M$

--- a/solutions/forallx-sol-prooftfl.tex
+++ b/solutions/forallx-sol-prooftfl.tex
@@ -187,16 +187,19 @@ Give a proof for each of the following arguments:
 \hypo{nfg}{\enot F \eif G}
 \hypo{fh}{F \eif H}
 \open
-	\hypo{f}{F}
-	\have{h}{H}\ce{fh, f}
-	\have{gh}{G \eor H}\oi{h}
-\close
-\open
-	\hypo{nf}{\enot F}
-	\have{g}{G}\ce{nfg, nf}
-	\have{gh1}{G \eor H}\oi{g}
-\close
-\have{con}{G \eor H}\tnd{f-gh, nf-gh1}
+        \hypo{ncon}{\enot (G \eor H)}
+        \open
+                \hypo{f}{F}
+                \have{h}{H}\ce{fh, f}
+                \have{gh1}{G \eor H}\oi{h}
+                \have{bot1}{\ered}\ri{ncon, gh1}
+        \close
+        \have{nf}{\enot F}\ni{f-bot1}
+        \have{g}{G}\ce{nfg,nf}
+        \have{gh2}{G \eor H}\oi{g}
+        \have{bot2}{\ered}\ri{ncon, gh2}
+\close        
+\have{con}{G \eor H}\ip{ncon-bot2}
 \end{proof}}
 
 \item $(Z\eand K) \eor (K\eand M), K \eif D \therefore D$


### PR DESCRIPTION
Finally got a chance to look into replacing the uses of TND in the solutions manual with the new rules. Here's a PR that gives new proofs for a couple of exercises in the TFL section of the book.

It didn't occur to me until after I did a few that we don't have to replace *every* use of TND, since it's still a derived rule. At least the proof for the exercise in chapter 15 needs to be replaced; but you might want to forget the two commits for the chapter 17 exercises, if you're OK with appeals to \tnd in chapter 17.

Should I work on any more of these?