### PR TITLE
Erased improper negation

### DIFF
--- a/forallx-yyc-fol.tex
+++ b/forallx-yyc-fol.tex
@@ -1547,7 +1547,7 @@ For instance, consider the English idiom,
 	\item[\ex{glitters}]
 	Everything that glitters is not gold.
 \end{earg}
-If we think of this sentence as of the form `every $F$ is not~$G$' where $\atom{F}{x}$ symbolizes `\gap{x} glitters' and $\atom{G}{x}$ is `\gap{x} is not gold', we would symbolize it as:
+If we think of this sentence as of the form `every $F$ is not~$G$' where $\atom{F}{x}$ symbolizes `\gap{x} glitters' and $\atom{G}{x}$ is `\gap{x} is gold', we would symbolize it as:
 \begin{earg}
 	\item[] $\forall x(\atom{F}{x} \eif \enot \atom{G}{x})$,
 \end{earg}


### PR DESCRIPTION
Erased improper negation at '\gap{x} is not gold' so it became '\gap{x} is gold'.