### PR TITLE
grammar, spelling, consistent spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ Cambridge_](https://www.homepages.ucl.ac.uk/~uctytbu/OERs.html), by
 under a [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 license, which is based in turn on [_forall
 x_](https://www.fecundity.com/logic/), by
-[P.D. Magnus](https://www.fecundity.com/job/) used under a [CC BY
+[P.~D. Magnus](https://www.fecundity.com/job/) used under a [CC BY
 4.0](https://creativecommons.org/licenses/by/3.0/) license, and was
 remixed, revised, & expanded by [Aaron
 Thomas-Bolduc](https://phil.ucalgary.ca/profiles/aaron-thomas-bolduc)
 & [Richard Zach](https://richardzach.org/).  It includes additional
-material from _forall x_ by P.D. Magnus and
+material from _forall x_ by P.~D. Magnus and
 [_Metatheory_](https://www.homepages.ucl.ac.uk/~uctytbu/OERs.html) by
 Tim Button, both used under a [CC BY
 4.0](https://creativecommons.org/licenses/by/4.0/) license, from

--- a/forallx-yyc-alternatives.tex
+++ b/forallx-yyc-alternatives.tex
@@ -32,7 +32,7 @@ Some systems take DS as their basic rule for disjunction elimination. Such syste
   \close
   \have{con}{\metav{C}}\ip{nc-bot2}
 \end{fitchproof}
-So why did we choose to take $\eor$E as basic, rather than DS?\footnote{P.D.\ Magnus's original version of this book went the other way.} Our reasoning is that DS involves the use of `$\enot$' in the statement of the rule. It is in some sense `cleaner' for our disjunction elimination rule to avoid mentioning \emph{other} connectives.
+So why did we choose to take $\eor$E as basic, rather than DS?\footnote{P.~D.\ Magnus's original version of this book went the other way.} Our reasoning is that DS involves the use of `$\enot$' in the statement of the rule. It is in some sense `cleaner' for our disjunction elimination rule to avoid mentioning \emph{other} connectives.
 
 
 \section{Alternative negation rules}
@@ -54,7 +54,7 @@ and a corresponding version of the rule we called IP as their basic negation eli
 	\close
 	\have[\ ]{a}{\metav{A}}\by{$\enot$E*}{na-nb}
 \end{fitchproof}
-Using these two rules, we could we could have avoided all use of the symbol `$\ered$' altogether.\footnote{Again, P.D.\ Magnus's original version of this book went the other way.} The resulting system would have had fewer rules than ours.
+Using these two rules, we could we could have avoided all use of the symbol `$\ered$' altogether.\footnote{Again, P.~D.\ Magnus's original version of this book went the other way.} The resulting system would have had fewer rules than ours.
 
 Another way to deal with negation is to use either LEM or DNE as a basic rule and introduce IP as a derived rule. Typically, in such a system the rules are given different names, too. E.g., sometimes what we call $\enot$E is called $\ered$I, and what we call X is called $\ered$E.\footnote{The version of this book due to Tim Button goes this route and replaces IP with LEM, which he calls TND, for ``tertium non datur.''}
 

--- a/forallx-yyc-fol.tex
+++ b/forallx-yyc-fol.tex
@@ -44,7 +44,7 @@ In English, a \emph{singular term} is a word or phrase that refers to a \emph{sp
 
 In FOL, our \define{names} are lower-case letters `$a$' through to `$r$'. We can add subscripts if we want to use some letter more than once. So here are some singular terms in FOL:
 	$$a,b,c,\ldots, r, a_1, f_{32}, j_{390}, m_{12}$$
-These should be thought of along the lines of proper names in English, but with one difference. `Tim Button' is a proper name, but there are several people with this name. (Equally, there are  at least two people with the name `P.D.\ Magnus'.) We live with this kind of ambiguity in English, allowing context to individuate the fact that `Tim Button' refers to an author of this book, and not some other Tim. In FOL, we do not tolerate any such ambiguity. Each name must pick out \emph{exactly} one thing. (However, two different names may pick out the same thing.)
+These should be thought of along the lines of proper names in English, but with one difference. `Tim Button' is a proper name, but there are several people with this name. (Equally, there are  at least two people with the name `P.~D.\ Magnus'.) We live with this kind of ambiguity in English, allowing context to individuate the fact that `Tim Button' refers to an author of this book, and not some other Tim. In FOL, we do not tolerate any such ambiguity. Each name must pick out \emph{exactly} one thing. (However, two different names may pick out the same thing.)
 
 \newglossaryentry{name}{
   name = name,
@@ -283,8 +283,8 @@ In \S\ref{s:FOLBuildingBlocks}, we emphasized that a name must pick out exactly 
 
 Suppose we want to symbolize these two sentences:
 	\begin{earg}
-		\item[\ex{monkey1}] Every monkey knows sign language
-		\item[\ex{monkey2}] Some monkey knows sign language
+		\item[\ex{monkey1}] Every monkey knows sign language.
+		\item[\ex{monkey2}] Some monkey knows sign language.
 	\end{earg}
 It is possible to write the symbolization key for these sentences in this way:
 	\begin{ekey}
@@ -380,7 +380,7 @@ The moral is that the English words `any' and `anyone' should typically be symbo
 \section{Quantifiers and scope}
 Continuing the example, suppose we want to symbolize these sentences:
 	\begin{earg}
-		\item[\ex{qscope1}] If everyone is a bassist, then Lars is a bassist
+		\item[\ex{qscope1}] If everyone is a bassist, then Lars is a bassist.
 		\item[\ex{qscope2}] Everyone is such that, if they are a bassist, then Lars is a bassist.
 	\end{earg}
 To symbolize these sentences, we will have to add a new name to the symbolization key, namely:
@@ -460,9 +460,9 @@ Must we always distinguish between different ways of being skilled, good, bad, o
 \label{pr.BarbaraEtc}
 Here are the syllogistic figures identified by Aristotle and his successors, along with their medieval names:
 \begin{earg}
-	\item \textbf{Barbara.} All G are F. All H are G. So:  All H are F
-	\item \textbf{Celarent.} No G are F. All H are G. So: No H are F
-	\item \textbf{Ferio.} No G are F. Some H is G. So: Some H is not F
+	\item \textbf{Barbara.} All G are F. All H are G. So:  All H are F.
+	\item \textbf{Celarent.} No G are F. All H are G. So: No H are F.
+	\item \textbf{Ferio.} No G are F. Some H is G. So: Some H is not F.
 	\item \textbf{Darii.} All G are F. Some H is G. So: Some H is F.
 	\item \textbf{Camestres.} All F are G. No H are G. So: No H are F.
 	\item \textbf{Cesare.} No F are G. All H are G. So: No H are F.
@@ -535,7 +535,7 @@ symbolize each of the following sentences in FOL:
 \label{pr.FOLarguments}
 For each argument, write a symbolization key and symbolize the argument in FOL.
 \begin{earg}
-\item Willard is a logician. All logicians wear funny hats. So Willard wears a funny hat
+\item Willard is a logician. All logicians wear funny hats. So Willard wears a funny hat.
 \item Nothing on my desk escapes my attention. There is a computer on my desk. As such, there is a computer that does not escape my attention.
 \item All my dreams are black and white. Old TV shows are in black and white. Therefore, some of my dreams are old TV shows.
 \item Neither Holmes nor Watson has been to Australia. A person could see a kangaroo only if they had been to Australia or to a zoo. Although Watson has not seen a kangaroo, Holmes has. Therefore, Holmes has been to a zoo.
@@ -867,11 +867,11 @@ symbolize the following sentences in FOL:
 Using the symbolization key given, symbolize each English-language sentence into FOL.
 \begin{ekey}
 \item[\text{domain}] candies
-\item[\atom{C}{x}] \gap{x} has chocolate in it.
-\item[\atom{M}{x}] \gap{x} has marzipan in it.
-\item[\atom{S}{x}] \gap{x} has sugar in it.
-\item[\atom{T}{x}] Boris has tried \gap{x}.
-\item[\atom{B}{x,y}] \gap{x} is better than \gap{y}.
+\item[\atom{C}{x}] \gap{x} has chocolate in it
+\item[\atom{M}{x}] \gap{x} has marzipan in it
+\item[\atom{S}{x}] \gap{x} has sugar in it
+\item[\atom{T}{x}] Boris has tried \gap{x}
+\item[\atom{B}{x,y}] \gap{x} is better than \gap{y}
 \end{ekey}
 \begin{earg}
 \item Boris has never tried any candy.
@@ -890,11 +890,11 @@ Using the symbolization key given, symbolize each English-language sentence into
 Using the following symbolization key:
 \begin{ekey}
 \item[\text{domain}] people and dishes at a potluck
-\item[\atom{R}{x}] \gap{x} has run out.
-\item[\atom{T}{x}] \gap{x} is on the table.
-\item[\atom{F}{x}] \gap{x} is food.
-\item[\atom{P}{x}] \gap{x} is a person.
-\item[\atom{L}{x,y}] \gap{x} likes \gap{y}.
+\item[\atom{R}{x}] \gap{x} has run out
+\item[\atom{T}{x}] \gap{x} is on the table
+\item[\atom{F}{x}] \gap{x} is food
+\item[\atom{P}{x}] \gap{x} is a person
+\item[\atom{L}{x,y}] \gap{x} likes \gap{y}
 \item[e] Eli
 \item[f] Francesca
 \item[g] the guacamole
@@ -919,11 +919,11 @@ symbolize the following English sentences in FOL:
 Using the following symbolization key:
 \begin{ekey}
 \item[\text{domain}] people
-\item[\atom{D}{x}] \gap{x} dances ballet.
-\item[\atom{F}{x}] \gap{x} is female.
-\item[\atom{M}{x}] \gap{x} is male.
-\item[\atom{C}{x,y}] \gap{x} is a child of \gap{y}.
-\item[\atom{S}{x,y}] \gap{x} is a sibling of \gap{y}.
+\item[\atom{D}{x}] \gap{x} dances ballet
+\item[\atom{F}{x}] \gap{x} is female
+\item[\atom{M}{x}] \gap{x} is male
+\item[\atom{C}{x,y}] \gap{x} is a child of \gap{y}
+\item[\atom{S}{x,y}] \gap{x} is a sibling of \gap{y}
 \item[e] Elmer
 \item[j] Jane
 \item[p] Patrick
@@ -950,7 +950,7 @@ symbolize the following sentences in FOL:
 
 Consider this sentence:
 \begin{earg}
-\item[\ex{else1}] Pavel owes money to everyone
+\item[\ex{else1}] Pavel owes money to everyone.
 \end{earg}
 Let the domain be people; this will allow us to symbolize `everyone' with a universal quantifier. Offering the symbolization key:
 	\begin{ekey}
@@ -959,8 +959,8 @@ Let the domain be people; this will allow us to symbolize `everyone' with a univ
 	\end{ekey}
 we can symbolize sentence \ref{else1} by `$\forall x\, \atom{O}{p,x}$'. But this has a (perhaps) odd consequence. It requires that Pavel owes money to every member of the domain (whatever the domain may be). The domain certainly includes Pavel. So this entails that Pavel owes money to himself. And maybe we did not want to say that. Maybe we meant to leave it open if Pavel owes money to himself, something we could have expressed more precisely by using either on of the following:
 	\begin{earg}
-		\item[\ex{else1b}] Pavel owes money to everyone \emph{else}
-		\item[\ex{else1c}] Pavel owes money to everyone \emph{other than} Pavel
+		\item[\ex{else1b}] Pavel owes money to everyone \emph{else}.
+		\item[\ex{else1c}] Pavel owes money to everyone \emph{other than} Pavel.
 	\end{earg}
 But we do not have any way for dealing with the italicised words yet. The solution is to add another symbol to FOL.
 
@@ -974,17 +974,17 @@ This does not mean \emph{merely} that the objects in question are indistinguisha
 
 To put this to use, suppose we want to symbolize this sentence:
 \begin{earg}
-\item[\ex{else2}] Pavel is Mister Checkov.
+\item[\ex{else2}] Pavel is Mister Chekov.
 \end{earg}
 Let us add to our symbolization key:
 	\begin{ekey}
-		\item[c] Mister Checkov
+		\item[c] Mister Chekov
 	\end{ekey}
 Now sentence \ref{else2} can be symbolized as `$p=c$'. This tells us that the names `$p$' and `$c$' both name the same thing.
 
 We can also now deal with sentences \ref{else1b} and~\ref{else1c}. Both of these sentences can be  paraphrased as `Everyone who is not Pavel is owed money by Pavel'. Paraphrasing some more, we get: `For all $x$, if $x$ is not Pavel, then $x$ is owed money by Pavel'. Now that we are armed with our new identity symbol, we can symbolize this as `$\forall x (\enot x = p \eif \atom{O}{p,x})$'.
 
-This last sentence contains the formula `$\enot x = p$'. That might look a bit strange, because the symbol that comes immediately after the `$\enot$' is a variable, rather than a predicate, but this is not a problem. We are simply negating the entire formula, `$x = p$'.
+This last sentence contains the formula `$\enot x = p$'. That might look a bit strange, because the symbol that comes immediately after the `$\enot$' is a variable, rather than a predicate, but this is not a problem. We are simply negating the entire formula `$x = p$'.
 
 \section{`Only' and `except'}
 
@@ -995,7 +995,7 @@ In addition to sentences that use the word `else', and `other than', identity is
 Let `$h$' name Hikaru. Plausibly, sentence~\ref{only1} is true if, and only if, both of the following conditions hold:
 \begin{earg}
 	\item[\ex{only2}] Pavel owes money to Hikaru.
-	\item[\ex{else3}] Noone who is not Pavel owes money to Hikaru.
+	\item[\ex{else3}] No one who is not Pavel owes money to Hikaru.
 \end{earg}
 Sentence \ref{else3} can be symbolized by any one of:
 \begin{align*}
@@ -1008,16 +1008,16 @@ Thus, we can symbolize sentence~\ref{only1} as the conjunction of one of the abo
 \begin{earg}
 	\item[\ex{except}] Everyone except Pavel owes money to Hikaru.
 	\end{earg}
-Sentence \ref{except} can be treated similarly, although now of course Pavel does \emph{not} owe Hikaru money. We can paraphrase it as `Everyone who is not Pavel owes Hikaru money, and Pavel does not'. Consequently, it can be symbolized as, `$\forall x(\enot x = p \eif \atom{O}{x,h}) \eand \enot \atom{O}{p,h}$', or more concisely, `$\forall x(\enot x = p \eiff \atom{O}{x,h})$'. Other locutions akin to `except' such as `but' or `besides' (as used in `noone but Pavel' or `someone besides Hikaru') can be treated in similary ways.
+Sentence \ref{except} can be treated similarly, although now of course Pavel does \emph{not} owe Hikaru money. We can paraphrase it as `Everyone who is not Pavel owes Hikaru money, and Pavel does not'. Consequently, it can be symbolized as `$\forall x(\enot x = p \eif \atom{O}{x,h}) \eand \enot \atom{O}{p,h}$', or more concisely, `$\forall x(\enot x = p \eiff \atom{O}{x,h})$'. Other locutions akin to `except' such as `but' or `besides' (as used in `no one but Pavel' or `someone besides Hikaru') can be treated in similary ways.
 
 The above treatment of so-called ``exceptives'' is not uncontentious. Some linguists think that sentence~\ref{except} does not entail that Pavel doesn't owe Hikaru money, and so the symbolization should just be `$\forall x(\enot x = p \eif \atom{O}{x,h})$'.  There are also uses of `except' that clearly do not have that entailment, especially in mathematical writing.  For instance, you may read in a calculus textbook that ``the function~$f$ is defined everywhere except possibly at~$a$''.  That means only that for every point~$x$ other than~$a$, $f$~is defined at~$x$. It is not required that $f$ is undefined at~$a$; it's left open whether $f$ is or is not defined at~$a$.
 
 \section{There are at least\ldots}
 We can also use identity to say how many things there are of a particular kind. For example, consider these sentences:
 \begin{earg}
-\item[\ex{atleast1}] There is at least one apple
-\item[\ex{atleast2}] There are at least two apples
-\item[\ex{atleast3}] There are at least three apples
+\item[\ex{atleast1}] There is at least one apple.
+\item[\ex{atleast2}] There are at least two apples.
+\item[\ex{atleast3}] There are at least three apples.
 \end{earg}
 We will use the symbolization key:
 	\begin{ekey}
@@ -1036,8 +1036,8 @@ Note that it is \emph{not} enough to use `$\lnot x = y \land \lnot y = z$' to sy
 \section{There are at most\ldots}
 Now consider these sentences:
 \begin{earg}
-	\item[\ex{atmost1}] There is at most one apple
-	\item[\ex{atmost2}] There are at most two apples
+	\item[\ex{atmost1}] There is at most one apple.
+	\item[\ex{atmost2}] There are at most two apples.
 \end{earg}
 Sentence \ref{atmost1} can be paraphrased as, `It is not the case that there are at least \emph{two} apples'. This is just the negation of sentence \ref{atleast2}: 
 $$\enot \exists x \exists y[(\atom{A}{x} \eand \atom{A}{y}) \eand \enot x = y]$$
@@ -1073,8 +1073,8 @@ More efficiently, though, we can paraphrase it as `There are at least two differ
 $$\exists x\exists y\bigl[((\atom{A}{x} \eand \atom{A}{y}) \eand \enot x = y) \eand \forall z(\atom{A}{z} \eif ( x= z \eor y = z))\bigr]$$
 Finally, consider these sentence:
 \begin{earg}
-\item[\ex{exactly2things}] There are exactly two things
-\item[\ex{exactly2objects}] There are exactly two objects
+\item[\ex{exactly2things}] There are exactly two things.
+\item[\ex{exactly2objects}] There are exactly two objects.
 \end{earg}
 It might be tempting to add a predicate to our symbolization key, to symbolize the English predicate `\blank\ is a thing' or `\blank\ is an object', but this is unnecessary. Words like `thing' and `object' do not sort wheat from chaff: they apply trivially to everything, which is to say, they apply trivially to every thing. So we can symbolize either sentence with either of the following:
 	\begin{align*}
@@ -1110,13 +1110,15 @@ It might be tempting to add a predicate to our symbolization key, to symbolize t
 %\item Any candy with chocolate and marzipan is better than any candy that lacks both.
 %\end{earg}
 
-\problempart Consider the sentence,
+\problempart 
+Consider the sentence,
 \begin{earg}
 	\item[\ex{except2}] Every officer except Pavel owes money to Hikaru.
 \end{earg}
 Symbolize this sentence, using `$\atom{F}{x}$' for `\gap{x} is an officer'.  Are you confident that your symbolization is true if, and only if, sentence~\ref{except2} is true?  What happens if every officer owes money to Hikaru, Pavel does not, but Pavel isn't an officer?
 
-\problempart Explain why:
+\problempart 
+Explain why:
 	\begin{ebullet}
 		\item   `$\exists x \forall y(\atom{A}{y} \eiff x= y)$' is a good symbolization of `there is exactly one apple'.
 		\item `$\exists x \exists y \bigl[\enot x = y \eand \forall z(\atom{A}{z} \eiff (x= z \eor y = z))\bigr]$' is a good symbolization of `there are exactly two apples'.
@@ -1392,7 +1394,7 @@ Using the following symbolization key:
 	\end{ekey}
 	(Note that the symbolization key speaks of \emph{a} present King of France, not \emph{the} present King of France; i.e., it employs indefinite, rather than definite, description.) Sentence \ref{kingdate} would be symbolized by `$\exists x \bigl[(\atom{K}{x} \eand \forall y(\atom{K}{y} \eif  x = y)) \eand \atom{D}{a,x}\bigr]$'. Now, this can be false in (at least) two ways, corresponding to these two different sentences:
 	\begin{earg}
-		\item[\ex{outernegation}] There is noone who is both the present King of France and such that he and Alex are dating.
+		\item[\ex{outernegation}] There is no one who is both the present King of France and such that he and Alex are dating.
 		\item[\ex{innernegation}] There is a unique present King of France, but Alex is not dating him.
 	\end{earg}
 Sentence \ref{outernegation} might be paraphrased by `It is not the case that: the present King of France and Alex are dating'. It will then be symbolized by `$\enot \exists x\bigl[(\atom{K}{x} \eand \forall y(\atom{K}{y} \eif  x = y)) \eand \atom{D}{a,x} \bigr]$'. We might call this \emph{outer} negation, since the negation governs the entire sentence. Note that the sentence is true if there is no present King of France.
@@ -1433,7 +1435,7 @@ The difference between the symbolization of this and that of `both $F$s are~$G$s
 \section{The adequacy of Russell's analysis}
 How good is Russell's analysis of definite descriptions? This question has generated a substantial philosophical literature, but we will restrict ourselves to two observations.
 
-One worry focusses on Russell's treatment of empty definite descriptions. If there are no $F$s, then on Russell's analysis, both `the $F$ is $G$' is and  `the $F$ is non-$G$' are false. P.F.\ Strawson suggested that such sentences should not be regarded as false, exactly, but involve \emph{presupposition failure}, and so need to be treated as \emph{neither} true \emph{nor} false.\footnote{P.F.\ Strawson, `On Referring', 1950, \emph{Mind 59}, pp.\ 320--34.}
+One worry focusses on Russell's treatment of empty definite descriptions. If there are no $F$s, then on Russell's analysis, both `the $F$ is $G$' is and  `the $F$ is non-$G$' are false. P.F.\ Strawson suggested that such sentences should not be regarded as false, exactly, but involve \emph{presupposition failure}, and so need to be treated as \emph{neither} true \emph{nor} false.\footnote{P.~F.\ Strawson, `On Referring', 1950, \emph{Mind 59}, pp.\ 320--34.}
 
 If we agree with Strawson here, we will need to revise our logic. For, in our logic, there are only two truth values (True and False), and every sentence is assigned exactly one of these truth values.
 
@@ -1449,7 +1451,7 @@ Russell's analysis will have us render Malika's sentence as:
 	\end{earg}
 Now suppose that the very tall man is actually drinking \emph{water} from a martini glass; whereas the very short man is drinking a pint of (neat) gin. By Russell's analysis, Malika has said something false, but don't we want to say that Malika has said something \emph{true}? 
 
-Again, one might wonder how clear our intuitions are on this case. We can all agree that Malika intended to pick out a particular man, and say something true of him (that he was tall). On Russell's analysis, she actually picked out a different man (the short one), and consequently said something false of him. But  maybe advocates of Russell's analysis only need to explain \emph{why} Malika's intentions were frustrated, and so why she said something false. This is easy enough to do:  Malika said something false because she had false beliefs about the men's drinks; if Malika's beliefs about the drinks had been true,  then she would have said something true.\footnote{Interested parties should read Saul Kripke, `Speaker Reference and Semantic Reference', 1977, in French et al (eds.), \emph{Contemporary Perspectives in the Philosophy of Language}, Minneapolis: University of Minnesota Press, pp.\ 6-27.}
+Again, one might wonder how clear our intuitions are on this case. We can all agree that Malika intended to pick out a particular man, and say something true of him (that he was tall). On Russell's analysis, she actually picked out a different man (the short one), and consequently said something false of him. But  maybe advocates of Russell's analysis only need to explain \emph{why} Malika's intentions were frustrated, and so why she said something false. This is easy enough to do:  Malika said something false because she had false beliefs about the men's drinks; if Malika's beliefs about the drinks had been true,  then she would have said something true.\footnote{Interested parties should read Saul Kripke, `Speaker Reference and Semantic Reference', 1977, in French et al.\ (eds.), \emph{Contemporary Perspectives in the Philosophy of Language}, Minneapolis: University of Minnesota Press, pp.\ 6--27.}
 
 To say much more here would lead us into deep philosophical waters. That would be no bad thing, but for now it would distract us from the immediate purpose of learning formal logic. So, for now, we will stick with Russell's analysis of definite descriptions, when it comes to putting things into FOL. It is certainly the best that we can offer, without significantly revising our logic, and it is quite defensible as an analysis.
 
@@ -1585,7 +1587,7 @@ In sections \ref{ss:OrderQuant} and \ref{ss:SuppQuant} we discussed the importan
 \begin{earg}
 	\item[\ex{everya}] Everyone went to see a movie.
 \end{earg}
-This sentence is ambiguous.  In one interpretatation, it means that there is a single movie that everyone went to see. In the  other, it means that everyone went to see some movie or other, but not necessarily the same one. The two readings can be symbolized, respectively, by 
+This sentence is ambiguous.  In one interpretation, it means that there is a single movie that everyone went to see. In the  other, it means that everyone went to see some movie or other, but not necessarily the same one. The two readings can be symbolized, respectively, by 
 \begin{earg}
 	\item[] $\exists x(\atom{M}{x} \eand \forall y(\atom{P}{y} \eif \atom{S}{y,x}))$
 	\item[] $\forall y(\atom{P}{y} \eif \exists x(\atom{M}{x} \eand \atom{S}{y,x}))$
@@ -1608,7 +1610,7 @@ If the definite description has wide scope, and we are interpreting the `not' as
 \problempart
 Each of the following sentences is ambiguous. Provide a symbolization key for each, and symbolize all readings.
 \begin{earg}
-	\item Noone likes a quitter.
+	\item No one likes a quitter.
 	\item CSI found only red hair at the scene.
 	\item Smith's murderer hasn't been arrested.
 \end{earg}

--- a/forallx-yyc-frontmatter.tex
+++ b/forallx-yyc-frontmatter.tex
@@ -49,7 +49,7 @@ used under a \href{https://creativecommons.org/licenses/by/4.0/}{CC BY
 and was remixed, revised, \& expanded by Aaron
 Thomas-Bolduc \& \href{https://richardzach.org/}{Richard Zach}
 (University of Calgary).
-It includes additional material from \forallx{} by P.D. Magnus and
+It includes additional material from \forallx{} by P.~D. Magnus and
 \href{https://www.homepages.ucl.ac.uk/~uctytbu/OERs.html}{\emph{Metatheory}} by Tim Button, 
 used under a \href{https://creativecommons.org/licenses/by/4.0/}{CC BY
 4.0} license, 

--- a/forallx-yyc-interpretations.tex
+++ b/forallx-yyc-interpretations.tex
@@ -113,12 +113,12 @@ Some philosophers have believed the reverse of this claim. That is, they have be
 
 To bring this out, consider the following interpretation:
 	\begin{ebullet}
-		\item[\text{domain}:] P.D.\ Magnus, Tim Button
-		\item[$a$:] P.D.\ Magnus
+		\item[\text{domain}:] P~D.\ Magnus, Tim Button
+		\item[$a$:] P.~D.\ Magnus
 		\item[$b$:] Tim Button
 		\item For every primitive predicate we care to consider, that predicate is true of \emph{nothing}.
 	\end{ebullet}
-Suppose `$A$' is a one-place predicate; then `$\atom{A}{a}$' is false and `$\atom{A}{b}$' is false, so `$\atom{A}{a} \eiff \atom{A}{b}$' is true. Similarly, if `$R$' is a two-place predicate, then `$\atom{R}{a,a}$' is false and `$\atom{R}{a,b}$' is false, so that `$\atom{R}{a,a} \eiff \atom{R}{a,b}$' is true. And so it goes: every atomic sentence not involving `$=$' is false, so every biconditional linking such sentences is true. For all that, Tim Button and P.D.\ Magnus are two distinct people, not one and the same!
+Suppose `$A$' is a one-place predicate; then `$\atom{A}{a}$' is false and `$\atom{A}{b}$' is false, so `$\atom{A}{a} \eiff \atom{A}{b}$' is true. Similarly, if `$R$' is a two-place predicate, then `$\atom{R}{a,a}$' is false and `$\atom{R}{a,b}$' is false, so that `$\atom{R}{a,a} \eiff \atom{R}{a,b}$' is true. And so it goes: every atomic sentence not involving `$=$' is false, so every biconditional linking such sentences is true. For all that, Tim Button and P.~D.\ Magnus are two distinct people, not one and the same!
 
 \section{Interpretations}
 We defined a \define{valuation} in TFL as any assignment of truth and falsity to sentence letters. In FOL, we are going to define an \define{interpretation} as consisting of four things:

--- a/forallx-yyc-tfl.tex
+++ b/forallx-yyc-tfl.tex
@@ -39,7 +39,7 @@ Again, this is a valid argument. The structure here is something like:
 A superb structure! Here is another example:
 	\begin{earg}
 		\item[] It's not the case that Jim both studied hard and acted in lots of plays.
-		\item[] Jim studied hard
+		\item[] Jim studied hard.
 		\item[\therefore] Jim did not act in lots of plays.
 	\end{earg}
 This valid argument has a structure which we might represent thus:
@@ -48,20 +48,20 @@ This valid argument has a structure which we might represent thus:
 		\item[] $A$
 		\item[\therefore] not-$B$
 	\end{earg}
-These examples illustrate an important idea, which we might describe as \emph{validity in virtue of form}. The validity of the arguments just considered has nothing very much to do with the meanings of English expressions like `Jenny is miserable', `Dipan is an avid reader of Tolstoy', or `Jim acted in lots of plays'. If it has to do with meanings at all, it is with the meanings of phrases like `and', `or', `not,' and `if\ldots, then\ldots'.
+These examples illustrate an important idea, which we might describe as \emph{validity in virtue of form}. The validity of the arguments just considered has nothing very much to do with the meanings of English expressions like `Jenny is miserable', `Dipan is an avid reader of Tolstoy', or `Jim acted in lots of plays'. If it has to do with meanings at all, it is with the meanings of phrases like `and', `or', `not,' and `if \ldots, then \ldots'.
 
 In Parts \ref{ch.TFL}--\ref{ch.NDTFL}, we are going to develop a formal language which allows us to symbolize many arguments in such a way as to show that they are valid in virtue of their form. That language will be \emph{truth-functional logic}, or TFL.
 
 \section{Validity for special reasons}
 There are plenty of arguments that are valid, but not for reasons relating to their form. Take an example:
 	\begin{earg}
-		\item[] Juanita is a vixen
-		\item[\therefore] Juanita is a fox
+		\item[] Juanita is a vixen.
+		\item[\therefore] Juanita is a fox.
 	\end{earg}
 It is impossible for the premise to be true and the conclusion false. So the argument is valid. However, the validity is not related to the form of the argument. Here is an invalid argument with the same form:
 	\begin{earg}
-		\item[] Juanita is a vixen
-		\item[\therefore] Juanita is a cathedral
+		\item[] Juanita is a vixen.
+		\item[\therefore] Juanita is a cathedral.
 	\end{earg}
 This might suggest that the validity of the first argument \emph{is} keyed to the meaning of the words `vixen' and `fox'. But, whether or not that is right, it is not simply the \emph{shape} of the argument that makes it valid. Equally, consider the argument:
 	\begin{earg}
@@ -347,9 +347,9 @@ It is important to bear in mind that the connective `\eif' tells us only that, i
 \section{Biconditional}
 Consider these sentences:
 	\begin{earg}
-		\item[\ex{iff1}] Laika is a dog only if she is a mammal
-		\item[\ex{iff2}] Laika is a dog if she is a mammal
-		\item[\ex{iff3}] Laika is a dog if and only if she is a mammal
+		\item[\ex{iff1}] Laika is a dog only if she is a mammal.
+		\item[\ex{iff2}] Laika is a dog if she is a mammal.
+		\item[\ex{iff3}] Laika is a dog if and only if she is a mammal.
 	\end{earg}
 We will use the following symbolization key:
 	\begin{ekey}
@@ -385,8 +385,8 @@ We have now introduced all of the connectives of TFL. We can use them together t
 \end{earg}
 These two sentences are clearly equivalent. To symbolize them, we will use the symbolization key:
 	\begin{ekey}
-		\item[J] You will wear a jacket.
-		\item[D] You will catch a cold.
+		\item[J] You will wear a jacket
+		\item[D] You will catch a cold
 	\end{ekey}
 Both sentences mean that if you do not wear a jacket, then you will catch a cold. With this in mind, we might symbolize them as `$(\enot J \eif D)$'.
 
@@ -406,9 +406,9 @@ Again, though, there is a little complication. `Unless' can be symbolized as a c
 \solutions
 \problempart Using the symbolization key given, symbolize each English sentence in TFL.\label{pr.monkeysuits}
 	\begin{ekey}
-		\item[M] Those creatures are men in suits.
-		\item[C] Those creatures are chimpanzees.
-		\item[G] Those creatures are gorillas.
+		\item[M] Those creatures are men in suits
+		\item[C] Those creatures are chimpanzees
+		\item[G] Those creatures are gorillas
 	\end{ekey}
 \begin{earg}
 \item Those creatures are not men in suits.
@@ -446,12 +446,12 @@ Again, though, there is a little complication. `Unless' can be symbolized as a c
 
 \problempart Using the symbolization key given, symbolize each English sentence in TFL.\label{pr.avacareer}
 	\begin{ekey}
-		\item[E_1] Ava is an electrician.
-		\item[E_2] Harrison is an electrician.
-		\item[F_1] Ava is a firefighter.
-		\item[F_2] Harrison is a firefighter.
-		\item[S_1] Ava is satisfied with her career.
-		\item[S_2] Harrison is satisfied with his career.
+		\item[E_1] Ava is an electrician
+		\item[E_2] Harrison is an electrician
+		\item[F_1] Ava is a firefighter
+		\item[F_2] Harrison is a firefighter
+		\item[S_1] Ava is satisfied with her career
+		\item[S_2] Harrison is satisfied with his career
 	\end{ekey}
 \begin{earg}
 \item Ava and Harrison are both electricians.
@@ -472,8 +472,8 @@ Again, though, there is a little complication. `Unless' can be symbolized as a c
 Using the symbolization key given, symbolize each English-language sentence in TFL.
 \label{pr.jazzinstruments}
 \begin{ekey}
-\item[J_1] John Coltrane played tenor sax.
-\item[J_2] John Coltrane played soprano sax.
+\item[J_1] John Coltrane played tenor sax
+\item[J_2] John Coltrane played soprano sax
 \item[J_3] John Coltrane played tuba
 \item[M_1] Miles Davis played trumpet
 \item[M_2] Miles Davis played tuba

--- a/forallx-yyc-what.tex
+++ b/forallx-yyc-what.tex
@@ -17,7 +17,7 @@ An argument, as we will understand it, is something more like this:
 		\item[] The butler didn't do it.
 		\item[\therefore] The gardener did it.
 	\end{earg}
-We here have a series of sentences. The three dots on the third line of the argument are read `therefore.' They indicate that the final sentence expresses the \emph{conclusion} of the argument. The two sentences before that are the \emph{premises} of the argument. If you believe the premises, and you think the conclusion follows from the premises---that the argument, as we will say, is valid---then this (perhaps) provides you with a reason to believe the conclusion.
+We have here a series of sentences. The three dots on the third line of the argument are read `therefore.' They indicate that the final sentence expresses the \emph{conclusion} of the argument. The two sentences before that are the \emph{premises} of the argument. If you believe the premises, and you think the conclusion follows from the premises---that the argument, as we will say, is valid---then this (perhaps) provides you with a reason to believe the conclusion.
 
 This is the sort of thing that logicians are interested in. We will say that an argument is any collection of premises, together with a conclusion.
 
@@ -207,25 +207,25 @@ For both of these notions of validity, aspects of the world (e.g., what the laws
 
 One distinguishing feature of \emph{logical} consequence, however, is that it should not depend on the content of the premises and conclusion, but only on their logical form. In other words, as logicians we want to develop a theory that can make finer-grained distinctions still. For instance, both
 \begin{earg}
-	\item[] Either Priya is an ophthalmologist or a dentist.
+	\item[] Priya is either an ophthalmologist or a dentist.
 	\item[] Priya isn't a dentist.
 	\item[\therefore] Priya is an eye doctor.
 \end{earg}
 and
 \begin{earg}
-	\item[] Either Priya is an ophthalmologist or a dentist.
+	\item[] Priya is either an ophthalmologist or a dentist.
 	\item[] Priya isn't a dentist.
 	\item[\therefore] Priya is an ophthalmologist.
 \end{earg}
 are valid arguments. But while the validity of the first depends on the content (i.e., the meaning of ``ophthalmologist'' and ``eye doctor''), the second does not. The second argument is \define{formally valid}. We can describe the ``form'' of this argument as a pattern, something like this:
 \begin{earg}
-	\item[] Either $A$ is an $X$ or a $Y$.
+	\item[] $A$ is either an $X$ or a $Y$.
 	\item[] $A$ isn't a $Y$.
 	\item[\therefore] $A$ is an $X$.
 \end{earg}
 Here, $A$, $X$, and $Y$ are placeholders for appropriate expressions that, when substituted for $A$, $X$, and $Y$, turn the pattern into an argument consisting of sentences. For instance,
 \begin{earg}
-	\item[] Either Mei is a mathematician or a botanist.
+	\item[] Mei is either a mathematician or a botanist.
 	\item[] Mei isn't a botanist.
 	\item[\therefore] Mei is a mathematician.
 \end{earg}
@@ -233,13 +233,13 @@ is an argument of the same form, but the first argument above is not: we would h
 
 Moreover, the first argument is not formally valid. \emph{Its} form is this:
 \begin{earg}
-	\item[] Either $A$ is an $X$ or a $Y$.
+	\item[] $A$ is either an $X$ or a $Y$.
 	\item[] $A$ isn't a $Y$.
 	\item[\therefore] $A$ is a $Z$.
 \end{earg}
 In this pattern we can replace $X$ by ``ophthalmologist'' and $Z$ by ``eye doctor'' to obtain the original argument.  But here is another argument of the same form:
 \begin{earg}
-	\item[] Either Mei is a mathematician or a botanist.
+	\item[] Mei is either a mathematician or a botanist.
 	\item[] Mei isn't a botanist.
 	\item[\therefore] Mei is an acrobat.
 \end{earg}
@@ -271,7 +271,7 @@ The premises and conclusion of this argument are, as a matter of fact, all true,
 
 The important thing to remember is that validity is not about the actual truth or falsity of the sentences in the argument. It is about whether it is \emph{possible} for all the premises to be true and the conclusion to be not true at the same time (in some hypothetical case). What is in fact the case has no special role to play; and what the facts are does not determine whether an argument is valid or not.\footnote{Well, there is one case where it does: if the premises are in fact true and the conclusion is in fact not true, then we live in a counterexample; so the argument is invalid.} Nothing about the way things are can by itself determine if an argument is valid. It is often said that logic doesn't care about feelings. Actually, it doesn't care about facts, either.
 
-When we use an argument to prove that its conclusion \emph{is true}, then, we need two things. First, we need the argument to be valid, i.e., we need the conclusion to follow from the premises. But we also need the premises to be true. We will say that an argument is \define{sound} if and only if it is both valid and all of its premises are true.
+When we use an argument to prove that its conclusion \emph{is true}, then, we need two things. First, we need the argument to be valid; i.e., we need the conclusion to follow from the premises. But we also need the premises to be true. We will say that an argument is \define{sound} if and only if it is both valid and all of its premises are true.
 
 \newglossaryentry{sound}
 {
@@ -306,7 +306,7 @@ Which of the following arguments are valid? Which are invalid?
 \end{earg}
 
 \begin{earg}
-\item Abe Lincoln was either born in Illinois or he was once president.
+\item Either Abe Lincoln was born in Illinois or he was once president.
 \item Abe Lincoln was never president.
 \item[\therefore] Abe Lincoln was born in Illinois.
 \end{earg}
@@ -318,8 +318,8 @@ Which of the following arguments are valid? Which are invalid?
 \end{earg}
 
 \begin{earg}
-\item Abe Lincoln was either from France or from Luxemborg.
-\item Abe Lincoln was not from Luxemborg.
+\item Abe Lincoln was either from France or from Luxembourg.
+\item Abe Lincoln was not from Luxembourg.
 \item[\therefore] Abe Lincoln was from France.
 \end{earg}
 
@@ -391,10 +391,10 @@ We can ask about the joint possibility of any number of sentences. For example, 
 	\begin{ebullet}	
 		\item[G1.] \label{MartianGiraffes} There are at least four giraffes at the wild animal park.
 		\item[G2.] There are exactly seven gorillas at the wild animal park.
-		\item[G3.] There are not more than two martians at the wild animal park.
-		\item[G4.] Every giraffe at the wild animal park is a martian.
+		\item[G3.] There are not more than two Martians at the wild animal park.
+		\item[G4.] Every giraffe at the wild animal park is a Martian.
 	\end{ebullet}
-G1 and G4 together entail that there are at least four martian giraffes at the park. This conflicts with G3, which implies that there are no more than two martian giraffes there. So the sentences G1--G4 are jointly impossible. They cannot all be true together. (Note that the sentences G1, G3 and G4 are jointly impossible. But if sentences are already jointly impossible, adding an extra sentence to the mix cannot make them jointly possible!)
+G1 and G4 together entail that there are at least four Martian giraffes at the park. This conflicts with G3, which implies that there are no more than two Martian giraffes there. So the sentences G1--G4 are jointly impossible. They cannot all be true together. (Note that the sentences G1, G3 and G4 are jointly impossible. But if sentences are already jointly impossible, adding an extra sentence to the mix cannot make them jointly possible!)
 
 \section[Necessary truths and falsehoods]{Necessary truths, necessary falsehoods, and contingency}
 
@@ -483,8 +483,8 @@ For each of the following: Is it a necessary truth, a necessary falsehood, or co
 \item Elephants dissolve in water.
 \item Wood is a light, durable substance useful for building things.
 \item If wood were a good building material, it would be useful for building things.
-\item I live in a three story building that is two stories tall.
-\item If gerbils were mammals they would nurse their young.
+\item I live in a three-story building that is two stories tall.
+\item If gerbils were mammals, they would nurse their young.
 \end{earg}
 
 \problempart Which of the following pairs of sentences are necessarily  equivalent? 
@@ -550,7 +550,7 @@ Which combinations of sentences are jointly possible? Mark each ``possible'' or 
 
 \problempart
 \label{pr.EnglishCombinations2}
-Which of the following is possible? If it is possible, give an example. If it is not possible, explain why.
+Which of the following are possible? For each, if it is possible, give an example. If it is not possible, explain why.
 \begin{earg}
 \item A valid argument that has one false premise and one true premise
 
@@ -574,7 +574,7 @@ Which of the following is possible? If it is possible, give an example. If it is
 \end{earg}
 
 \problempart
-Which of the following is possible? If it is possible, give an example. If it is not possible, explain why.
+Which of the following are possible? For each, if it is possible, give an example. If it is not possible, explain why.
 
 \begin{earg}
 \item A valid argument, whose premises are all necessary truths, and whose conclusion is contingent


### PR DESCRIPTION
Addressing several kinds of issues:

1. Fixed the parallelism issue we discussed in issue #58.
2. Fixed some spelling and capitalization like "Luxemburg" > "Luxembourg" and "martian" > "Martian".
3. Many periods were missing at the end of example sentences. I infer that the intended style is that **example sentences** should be rendered as sentences ending with periods, but that phrases in **symbolization keys**—even when they are effectively sentences—do not end with periods. But this style was inconsistently applied, so I tried to clean it up.
4. Some initialized names like "P. F. Strawson" had a space between initials, and some didn't. (Perhaps controversially), following Chicago's advice, I brought this into consistency in most cases by adding the space in in-text instances. (There are a few display and metadata instances of "P.D." I was nervous about changing and left, but could also change.) If you prefer that they be rendered consistently _without_ the space, I offer to do the work of going through with the help of a reg-ex and removing the space. I thought at least it should be consistent.