### PR TITLE
Note that '|' is sometimes used for 'or'

### DIFF
--- a/forallx-yyc-notation.tex
+++ b/forallx-yyc-notation.tex
@@ -26,7 +26,7 @@ In the history of formal logic, different symbols have been used at different ti
 
 \paragraph{Negation.} Two commonly used symbols are the \emph{hoe}, `$\neg$', and the \emph{swung dash} or \emph{tilde}, `${\sim}$.' In some more advanced formal systems it is necessary to distinguish between two kinds of negation; the distinction is sometimes represented by using both `$\neg$' and `${\sim}$'. Older texts sometimes indicate negation by a line over the formula being negated, e.g., $\overline{A \eand B}$. Some texts use `$x \neq y$' to abbreviate `$\enot x = y$'.
 
-\paragraph{Disjunction.} The symbol `$\vee$' is typically used to symbolize inclusive disjunction. One etymology is from the Latin word `vel', meaning `or'.%In some systems, disjunction is written as addition.
+\paragraph{Disjunction.} The symbol `$\vee$' is typically used to symbolize inclusive disjunction. One etymology is from the Latin word `vel', meaning `or'. The '$|$' symbol is also sometimes used.%In some systems, disjunction is written as addition.
 
 \paragraph{Conjunction.}
 Conjunction is often symbolized with the \emph{ampersand}, `{\&}'. The ampersand is a decorative form of the Latin word `et', which means `and'.  (Its etymology still lingers in certain fonts, particularly in italic fonts; thus an italic ampersand might appear as `\emph{\&}'.) This symbol is commonly used in natural English writing (e.g.  `Smith \& Sons'), and so even though it is a natural choice, many logicians use a different symbol to avoid confusion between the object and metalanguage: as a symbol in a formal system, the ampersand is not the English word `\&'. The most common choice now is `$\wedge$', which is a counterpart to the symbol used for disjunction. Sometimes a single dot, `{\scriptsize\textbullet}', is used. In some older texts, there is no symbol for conjunction at all; `$A$ and $B$' is simply written `$AB$'.
@@ -45,7 +45,7 @@ These alternative typographies are summarised below:
 \begin{tabular}{rl}
 negation & $\neg$, ${\sim}$\\
 conjunction & $\wedge$, $\&$, {\scriptsize\textbullet}\\
-disjunction & $\vee$\\
+disjunction & $\vee$, $|$\\
 conditional & $\rightarrow$, $\supset$\\
 biconditional & $\leftrightarrow$, $\equiv$\\
 universal quantifier & $\forall x$, $(x)$


### PR DESCRIPTION
This is true, for example, for prover9.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>