### PR TITLE
Little correction for forallx-yyc-truthtables.tex

### DIFF
--- a/forallx-yyc-truthtables.tex
+++ b/forallx-yyc-truthtables.tex
@@ -1028,8 +1028,8 @@ sometimes does not capture its intended truth conditions. But even our
 improvement, \cref{n:GodParadox2}, and its symbolization `$G \eif
 \enot M$' turned out to not be good enough. The phenomenon we
 encountered here is one of the so-called paradoxes of the material
-conditional. The paradox is that material conditionals like `$G \eif
-\enot M$' and `$G \eif \enot M$' are true whenever their
+conditional. The paradox is that material conditionals like
+`$G \eif M$' and `$G \eif \enot M$' are true whenever their
 antecedent~`$G$' is false, even though intuitively the two sentences
 `If God exists, She answers malevolent prayers' and `If God exists,
 She does \emph{not} answer malevolent prayers' should not both be true. This


### PR DESCRIPTION
There was repeated the expression `$G \eif \enot M$' two times, when in the book says for the first one: "If God exists, She answers malevolent prayers" (so, it should be just `$G \eif M$', as I edited) and for the second one "If God exists, She does not answer malevolent prayers" (which is the another `$G \eif \enot M$', that I left).