### PR TITLE
A small correction in the answer to question 4 of exercise A in chapt…

### DIFF
--- a/solutions/forallx-sol-fol.tex
+++ b/solutions/forallx-sol-fol.tex
@@ -466,7 +466,7 @@ symbolize the following sentences in FOL:
 \item Everyone who trusts Ingmar trusts someone who trusts a vegetarian.
 \item[] \myanswer{$\forall x\bigl[\atom{T}{x,i} \eif \exists y\bigr(\atom{T}{x,y} \eand \exists z(\atom{T}{y,z} \eand \atom{V}{z})\bigr)\bigr]$}
 \item Only Ingmar knows the combination to the safe.
-\item[] \myanswer{$\forall x(\atom{K}{i} \eif x = i)$\\Comment: does the English claim entail that Ingmar \emph{does} know the combination to the safe? If so, then we should formalize this with a `$\eiff$'.}
+\item[] \myanswer{$\forall x(\atom{K}{x} \eif x = i)$\\Comment: does the English claim entail that Ingmar \emph{does} know the combination to the safe? If so, then we should formalize this with a `$\eiff$'.}
 \item Ingmar trusts Hofthor, but no one else.
 \item[] \myanswer{$\forall x(\atom{T}{i,x} \eiff x = h)$}
 \item The person who knows the combination to the safe is a vegetarian.


### PR DESCRIPTION
…er 28.

The question says:
"Only Ingmar knows the combination to the safe"
(this answer as the comment below says, is taking true the case where Ingmar doesn't know the combination, so I respect that and my correction is not about that detail)

The answer written in the solutionary is: "∀x[ K(i) → ( x=i ) ]"  This isn't correct, because it says, that for all the elements in the domain, if "K(i)", then all the elements are "i". Which is only true if in the domain is just composed by the element "i", but false if not.

What I guess the author was referring to, is to "∀x[ K(x) → ( x=i ) ]", that, all the elements that fulfill "K" are "i". So, no element that isn't "i" is "K".

So, I just replace the letter "i" with the letter "x" :D